### PR TITLE
Removed "from collections import Iterable" in venn.py 

### DIFF
--- a/venn.py
+++ b/venn.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from itertools import chain
-from collections import Iterable
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 from matplotlib import colors


### PR DESCRIPTION
Removed line "from collections import Iterable" in venn.py  to avoid "Iterable" depricated issue